### PR TITLE
Add config.js to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "url": "https://github.com/mrsteele/dotenv-defaults/issues"
   },
   "files": [
-    "src"
+    "src",
+    "config.js"
   ],
   "homepage": "https://github.com/mrsteele/dotenv-defaults#readme",
   "dependencies": {


### PR DESCRIPTION
At the moment `config.js` is being ignored by NPM. This PR adds it.