### PR TITLE
chore(deps): upgrade dotenv to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1606,9 +1606,9 @@
       }
     },
     "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "homepage": "https://github.com/mrsteele/dotenv-defaults#readme",
   "dependencies": {
-    "dotenv": "^8.2.0"
+    "dotenv": "^10.0.0"
   },
   "devDependencies": {
     "jest": "^25.0.0",


### PR DESCRIPTION
Upgrade the `dotenv` package to v10.0.0 or above. This didn't seem to cause any issues in the tests, and I'm running on the `.nvmrc`-defined version of Node v10.x. Since you wanted to drop support for Node 8 & 9, I don't see any reason to test it further back in time.

Resolves #65